### PR TITLE
Fixed mod crashing on first launch and first run

### DIFF
--- a/src/main/java/com/schematical/chaoscraft/ChaosCraft.java
+++ b/src/main/java/com/schematical/chaoscraft/ChaosCraft.java
@@ -128,8 +128,10 @@ public class ChaosCraft
 
         auth();
 
-        startTrainingSession();
-        loadFitnessFunctions();
+        if(config.accessToken!=null) {
+            startTrainingSession();
+            loadFitnessFunctions();
+        }
 
 
 

--- a/src/main/java/com/schematical/chaoscraft/commands/CommandChaosCraftSessionStart.java
+++ b/src/main/java/com/schematical/chaoscraft/commands/CommandChaosCraftSessionStart.java
@@ -58,6 +58,7 @@ public class CommandChaosCraftSessionStart extends CommandBase {
 
 
         ChaosCraft.startTrainingSession();
+        ChaosCraft.loadFitnessFunctions();
         ChaosCraft.config.save();
         p_execute_2_.sendMessage(
             new TextComponentString("Successfully started a session - " + ChaosCraft.config.sessionNamespace)


### PR DESCRIPTION
If there is no accesstoken found the game will no longer try to load a trainingroom and fitness rules. 
The /chaoscraft-start command now also loads the fitness rules because they cant be loaded at launch on the first run.