### PR TITLE
Fixed adam only being able to spawned once

### DIFF
--- a/src/main/java/com/schematical/chaoscraft/commands/CommandChaosCraftAdam.java
+++ b/src/main/java/com/schematical/chaoscraft/commands/CommandChaosCraftAdam.java
@@ -111,6 +111,7 @@ public class CommandChaosCraftAdam extends CommandBase{
                 org.setCustomNameTag("adam");
             });
             ChaosCraft.chat("Adam Successfully Spawned!");
+            ChaosCraft.adam = entitys.get(0);
         } catch (Exception e) {
             ChaosCraft.logger.error(e.getMessage());
             e.printStackTrace();


### PR DESCRIPTION
ChaosCraft.adam was only set once, which would mean it didnt get killed when trying to resummon it and ChaosCraft.spawnOrgs would then fail and return no entities.