### PR TITLE
Update mappings to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20171003"
+    mappings = "stable_39"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 

--- a/src/main/java/com/schematical/chaoscraft/ai/inputs/BlockPositionInput.java
+++ b/src/main/java/com/schematical/chaoscraft/ai/inputs/BlockPositionInput.java
@@ -1,7 +1,6 @@
 package com.schematical.chaoscraft.ai.inputs;
 
 import com.schematical.chaoscraft.ai.InputNeuron;
-import com.schematical.chaoscraft.ai.biology.BiologyBase;
 import com.schematical.chaoscraft.ai.biology.BlockPositionSensor;
 import com.schematical.chaoscraft.util.PositionRange;
 import net.minecraft.block.Block;
@@ -34,7 +33,7 @@ public class BlockPositionInput                                                 
                     switch(attributeId){
                         case(com.schematical.chaoscraft.Enum.BLOCK_ID):
                             ResourceLocation regeistryName = block.getRegistryName();
-                            String key = regeistryName.getResourceDomain() + ":" + regeistryName.getResourcePath();
+                            String key = regeistryName.getNamespace() + ":" + regeistryName.getPath();
                             if(attributeValue.equals(key)){
                                 _lastValue = 1;
                             }

--- a/src/main/java/com/schematical/chaoscraft/ai/outputs/CraftOutput.java
+++ b/src/main/java/com/schematical/chaoscraft/ai/outputs/CraftOutput.java
@@ -1,15 +1,12 @@
 package com.schematical.chaoscraft.ai.outputs;
 
 import com.schematical.chaoscraft.ChaosCraft;
-import com.schematical.chaoscraft.ai.CCAttributeId;
 import com.schematical.chaoscraft.ai.OutputNeuron;
 import com.schematical.chaoscraft.events.CCWorldEvent;
-import com.schematical.chaoscraft.events.CCWorldEventType;
 import com.schematical.chaosnet.model.ChaosNetException;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import org.json.simple.JSONObject;
 
@@ -26,7 +23,7 @@ public class CraftOutput extends OutputNeuron {
         {
 
             ResourceLocation resourceLocation = irecipe.getRegistryName();
-            String key = resourceLocation.getResourceDomain() + ":" + resourceLocation.getResourcePath();
+            String key = resourceLocation.getNamespace() + ":" + resourceLocation.getPath();
             if(recipeId.equals(key)){
                 recipe = irecipe;
             }

--- a/src/main/java/com/schematical/chaoscraft/entities/EntityOrganism.java
+++ b/src/main/java/com/schematical/chaoscraft/entities/EntityOrganism.java
@@ -12,7 +12,6 @@ import com.schematical.chaoscraft.ai.NeuralNet;
 import com.schematical.chaoscraft.ai.OutputNeuron;
 import com.schematical.chaoscraft.ai.biology.BiologyBase;
 import com.schematical.chaoscraft.events.CCWorldEvent;
-import com.schematical.chaoscraft.events.CCWorldEventType;
 import com.schematical.chaoscraft.events.OrgEvent;
 import com.schematical.chaoscraft.fitness.EntityFitnessManager;
 import com.schematical.chaoscraft.gui.CCOrgDetailView;
@@ -34,7 +33,6 @@ import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -49,7 +47,6 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemStackHandler;
@@ -694,7 +691,7 @@ public class EntityOrganism extends EntityLiving {
 
             boolean bool = world.setBlockState(pos, net.minecraft.init.Blocks.AIR.getDefaultState(), world.isRemote ? 11 : 3);
             if (bool) {
-                state.getBlock().onBlockDestroyedByPlayer(world, pos, state);
+                state.getBlock().onPlayerDestroy(world, pos, state);
             } else {
                 harvest = false;
             }

--- a/src/main/java/com/schematical/chaoscraft/fitness/EntityFitnessRule.java
+++ b/src/main/java/com/schematical/chaoscraft/fitness/EntityFitnessRule.java
@@ -2,20 +2,15 @@ package com.schematical.chaoscraft.fitness;
 
 import com.schematical.chaoscraft.ChaosCraft;
 import com.schematical.chaoscraft.Enum;
-import com.schematical.chaoscraft.ai.NeuronDep;
 import com.schematical.chaoscraft.entities.EntityFitnessScoreEvent;
 import com.schematical.chaoscraft.events.CCWorldEvent;
 import com.schematical.chaosnet.model.ChaosNetException;
-import net.minecraft.block.Block;
-import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
-import java.awt.*;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -76,7 +71,7 @@ public class EntityFitnessRule {
                    }
 
                    resourceLocation = event.block.getRegistryName();
-                   String blockId = resourceLocation.getResourceDomain() + ":" + resourceLocation.getResourcePath();
+                   String blockId = resourceLocation.getNamespace() + ":" + resourceLocation.getPath();
                    //ChaosCraft.logger.info("Testing: " + blockId);
                    if(!attributeValue.contains(blockId)){
                        return null;
@@ -88,7 +83,7 @@ public class EntityFitnessRule {
                    }
 
                    resourceLocation = EntityRegistry.getEntry(event.entity.getClass()).getRegistryName();
-                   String entityId = resourceLocation.getResourceDomain() + ":" + resourceLocation.getResourcePath();
+                   String entityId = resourceLocation.getNamespace() + ":" + resourceLocation.getPath();
                    if(!attributeValue.contains(entityId)){
                        return null;
                    }
@@ -98,7 +93,7 @@ public class EntityFitnessRule {
                        ChaosCraft.logger.error("No `item` to check against!");
                    }
                    resourceLocation = event.item.getRegistryName();
-                   String itemId = resourceLocation.getResourceDomain() + ":" + resourceLocation.getResourcePath();
+                   String itemId = resourceLocation.getNamespace() + ":" + resourceLocation.getPath();
 
 
                    if(!attributeValue.contains(itemId)){

--- a/src/main/java/com/schematical/chaoscraft/gui/ChaosCraftGUI.java
+++ b/src/main/java/com/schematical/chaoscraft/gui/ChaosCraftGUI.java
@@ -28,7 +28,7 @@ public class ChaosCraftGUI {
     }
     public static void drawDebugLine(BlockPos startBlockPos, BlockPos endPos){
         Vec3d start = new Vec3d(startBlockPos.getX(), startBlockPos.getY(), startBlockPos.getZ());
-        Vec3d end = start.addVector(0, 10, 0);
+        Vec3d end = start.add(0, 10, 0);
         drawDebugLine(start, end);
     }
     public static void drawDebugLine(Vec3d start, Vec3d end){

--- a/src/main/java/com/schematical/chaoscraft/items/DebugItem.java
+++ b/src/main/java/com/schematical/chaoscraft/items/DebugItem.java
@@ -2,13 +2,10 @@ package com.schematical.chaoscraft.items;
 
 import com.schematical.chaoscraft.ChaosCraft;
 import com.schematical.chaoscraft.entities.EntityEvilRabbit;
-
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.projectile.EntityFishHook;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
@@ -20,7 +17,7 @@ public class DebugItem extends Item {
 
     public DebugItem() {
         this.setRegistryName(new ResourceLocation(ChaosCraft.MODID, "debug_item"));
-        this.setUnlocalizedName("debug_item");
+        this.setTranslationKey("debug_item");
     }
 
     @Override


### PR DESCRIPTION
Update the mappings to stable_39 to make sure we are using the latest mappings.
This way we will see less things like func_xxxx_x
This will probably result in errors for people who are making other changes, tho most names are still the same.