### PR TITLE
Fix shadowJar not being reobfed causing missingField errors to occur

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,8 +152,13 @@ shadowJar {
     classifier = ''
 }
 
-jar.enabled(false)
-jar.dependsOn(shadowJar)
+reobf {
+    shadowJar {} // Reobfuscate the shadowed JAR
+}
+
+artifacts {
+    archives shadowJar
+}
 
 // Example configuration to allow publishing using the maven-publish task
 // we define a custom artifact that is sourced from the reobfJar output task


### PR DESCRIPTION
This fixes the issue found yesterday after the stream.
The jar should be reobfed, but it only reobfed the normal jar and not the shadow jar. This fixes that

The mod still doesn't work for me, but it does load. A lot of nullpointers happen, but that seems to be a differetn issue